### PR TITLE
Preserve extended encoded character URLs

### DIFF
--- a/src/sceneBuilder.ts
+++ b/src/sceneBuilder.ts
@@ -80,7 +80,7 @@ import { FirebaseInstance } from "./fb";
 // import { MmdPlayerControl } from "babylon-mmd/esm/Runtime/Util/mmdPlayerControl";
 import { mobileMmdPlayerControl } from "./mobileMmdPlayerControl";
 import type { BaseCharData, GenshinCharData, HSRCharData, ZZZCharData, WuwaCharData, HNACharData, NTECharData, ExtraCharData } from "./sceneBuilder.types";
-import { normalize, getFirstDigit, findCharByName, findCharById, findAllCharsByName, filterBy, sortBy } from "./sceneBuilder.utils";
+import { normalize, getFirstDigit, findCharByName, findCharById, findAllCharsByName, filterBy, sortBy, createCharacterSlug } from "./sceneBuilder.utils";
 import { afterBuildSingleMaterialDefault, afterBuildSingleMaterialSt } from "./sceneBuilder.materials";
 import { createGenshinUI } from "./ui/genshinUI";
 import { createZzzUI } from "./ui/zzzUI";
@@ -476,6 +476,7 @@ export class SceneBuilder implements ISceneBuilder {
         let prevCharName: string;
         let prevCharId: number;
         let chosenCharName = item;
+        const initialCharacterSlug = createCharacterSlug(chosenCharName);
         let chosenChar: BaseCharData | undefined;
         let tabMode = "Genshin";
         let firstTabMode = tabMode;
@@ -492,8 +493,10 @@ export class SceneBuilder implements ISceneBuilder {
         // Update URL to reflect the loaded character (keep slug in address bar)
         {
             const urlBasePath = isLocal ? "" : "/model-viewer";
-            const charSlug = chosenCharName.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/ /g, "%20");
-            window.history.replaceState(null, "", urlBasePath + "/" + charSlug);
+            const charSlug = createCharacterSlug(chosenCharName);
+            if (!initialCharacterSlug.startsWith(`${charSlug}%20`)) {
+                window.history.replaceState(null, "", urlBasePath + "/" + charSlug);
+            }
         }
 
         if (chosenChar && chosenChar.directory && chosenChar.pmx) {
@@ -2019,7 +2022,7 @@ export class SceneBuilder implements ISceneBuilder {
             // Update URL to reflect the new character
             {
                 const urlBasePath = isLocal ? "" : "/model-viewer";
-                const charSlugCC = chosenCharName.toLowerCase().replace(/[^a-z0-9 ]/g, "").replace(/ /g, "%20");
+                const charSlugCC = createCharacterSlug(chosenCharName);
                 window.history.replaceState(null, "", urlBasePath + "/" + charSlugCC);
             }
 

--- a/src/sceneBuilder.utils.ts
+++ b/src/sceneBuilder.utils.ts
@@ -1,9 +1,19 @@
-// Pure helpers extracted from sceneBuilder.ts — no logic changes.
+// Pure helpers shared by sceneBuilder.ts.
+export const decodePathItem = (str: string): string => {
+    try {
+        return decodeURIComponent(str);
+    } catch {
+        return str.replace(/%20/gi, " ");
+    }
+};
+
 export const normalize = (str: string): string =>
-    str
-        .replace(/%20/g, " ")
+    decodePathItem(str)
         .toLowerCase()
         .replace(/[^a-z0-9 ]/g, "");
+
+export const createCharacterSlug = (str: string): string =>
+    normalize(str).trim().replace(/ +/g, " ").replace(/ /g, "%20");
 
 export const getFirstDigit = (num: number): number => {
     const str = Math.abs(num).toString();


### PR DESCRIPTION
## What?
Decode percent-encoded route terms before character search so shared URLs such as `/silver%20wolf%20lv999` resolve consistently.

Preserve extended shared URL tails on initial load instead of rewriting them down to the base character slug, for example keeping `/silver%20wolf%20lv999` instead of canonicalizing it to `/silver%20wolf`.

Reuse the shared character slug helper for later manual character changes so URL generation stays consistent after the initial route is loaded.

## Why?
This fixes the URL persistence addendum from https://github.com/Phoshco/model-viewer/issues/18#issuecomment-4374451131.

Shared viewer links can include encoded terms beyond the base character name. Those links should still find the intended character while preserving the original meaningful URL path the user opened.

## How?
The route term normalization now decodes percent-encoded input before the MiniSearch character lookup path uses it.

Initial-load behavior now avoids replacing an extended incoming route with the shorter canonical character slug. Manual character changes still generate clean slugs through the shared `createCharacterSlug` helper.

## Testing?
- Ran helper checks with `npx ts-node --transpile-only --eval "import { createCharacterSlug, normalize } from './src/sceneBuilder.utils'; const cases: [string, string][] = [[normalize('silver%20wolf%20lv999'), 'silver wolf lv999'], [normalize('silver wolf lv999'), 'silver wolf lv999'], [createCharacterSlug('Silver Wolf'), 'silver%20wolf'], [createCharacterSlug('Silver  Wolf  Lv999'), 'silver%20wolf%20lv999']]; for (const [actual, expected] of cases) { if (actual !== expected) { throw new Error('Expected ' + expected + ', received ' + actual); } } console.log('helper checks passed');"`.
- Ran a MiniSearch smoke check using `docs/res/assets/HSR/hsr.json`; `silver%20wolf%20lv999` resolves to `Silver Wolf`.
- `npm run build` was not completed in this checkout because ignored or missing local inputs (`res/` assets and `src/fb.ts`) block the build, followed by existing strict TypeScript errors once webpack compiles `sceneBuilder.ts`.
- `npm run lint` was not completed because `eslint.config.mjs` imports `@stylistic/eslint-plugin-js`, which is not installed by the current lockfile.

## Screenshots (optional)
Not applicable. This is URL parsing and route persistence behavior, not a visual UI change.

## Anything Else?
The scope is intentionally limited to route normalization, initial URL preservation, and shared slug generation. No asset, search index, or rendering behavior is changed.